### PR TITLE
[feat] 어드민 권한 검사 기능 추가

### DIFF
--- a/src/main/java/com/chiliclub/chilichat/entity/AdminEntity.java
+++ b/src/main/java/com/chiliclub/chilichat/entity/AdminEntity.java
@@ -1,6 +1,7 @@
 package com.chiliclub.chilichat.entity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +25,10 @@ public class AdminEntity extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_no")
     private ChatRoomEntity chatRoom;
+
+    @Builder
+    public AdminEntity(UserEntity user, ChatRoomEntity chatRoom) {
+        this.user = user;
+        this.chatRoom = chatRoom;
+    }
 }

--- a/src/main/java/com/chiliclub/chilichat/repository/AdminRepository.java
+++ b/src/main/java/com/chiliclub/chilichat/repository/AdminRepository.java
@@ -2,6 +2,13 @@ package com.chiliclub.chilichat.repository;
 
 import com.chiliclub.chilichat.entity.AdminEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface AdminRepository extends JpaRepository<AdminEntity, Long> {
+
+    @Query("SELECT a from AdminEntity a WHERE a.user.no = :userNo")
+    Optional<AdminEntity> findByUserNo(@Param("userNo") Long userNo);
 }

--- a/src/main/java/com/chiliclub/chilichat/service/AdminService.java
+++ b/src/main/java/com/chiliclub/chilichat/service/AdminService.java
@@ -1,0 +1,36 @@
+package com.chiliclub.chilichat.service;
+
+import com.chiliclub.chilichat.common.exception.ResourceNotFoundException;
+import com.chiliclub.chilichat.entity.AdminEntity;
+import com.chiliclub.chilichat.entity.ChatRoomEntity;
+import com.chiliclub.chilichat.repository.AdminRepository;
+import com.chiliclub.chilichat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public AdminEntity findAdmin(Long userNo) {
+
+        return adminRepository.findByUserNo(userNo)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 user_no를 가진 방장이 존재하지 않습니다"));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean checkIsAdmin(Long userNo, Long chatRoomNo) {
+
+        AdminEntity adminEntity = findAdmin(userNo);
+        ChatRoomEntity chatRoomEntity = chatRoomRepository.findById(chatRoomNo)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 chat_room_no를 지닌 채팅방이 존재하지 않습니다"));
+
+        return adminEntity.getChatRoom() == chatRoomEntity;
+    }
+}

--- a/src/main/java/com/chiliclub/chilichat/service/UserService.java
+++ b/src/main/java/com/chiliclub/chilichat/service/UserService.java
@@ -1,6 +1,7 @@
 package com.chiliclub.chilichat.service;
 
 import com.chiliclub.chilichat.common.exception.InvalidReqParamException;
+import com.chiliclub.chilichat.common.exception.ResourceNotFoundException;
 import com.chiliclub.chilichat.common.exception.UserNotAuthorizedException;
 import com.chiliclub.chilichat.component.TokenProvider;
 import com.chiliclub.chilichat.entity.UserEntity;
@@ -14,6 +15,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -67,5 +69,16 @@ public class UserService {
         UserDetailsImpl principal = (UserDetailsImpl) authentication.getPrincipal();
 
         return tokenProvider.generateToken(principal);
+    }
+
+    public Long getCurrentUserNo() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetailsImpl principal = (UserDetailsImpl) authentication.getPrincipal();
+
+        UserEntity userEntity = userRepository.findByLoginId(principal.getUsername())
+                .orElseThrow(() -> new ResourceNotFoundException("현재 인증된 유저가 존재하지 않습니다"));
+
+        return userEntity.getNo();
     }
 }

--- a/src/test/java/com/chiliclub/chilichat/repository/AdminRepositoryTest.java
+++ b/src/test/java/com/chiliclub/chilichat/repository/AdminRepositoryTest.java
@@ -1,0 +1,14 @@
+package com.chiliclub.chilichat.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AdminRepositoryTest {
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+}

--- a/src/test/java/com/chiliclub/chilichat/service/AdminServiceTest.java
+++ b/src/test/java/com/chiliclub/chilichat/service/AdminServiceTest.java
@@ -1,0 +1,148 @@
+package com.chiliclub.chilichat.service;
+
+import com.chiliclub.chilichat.common.exception.ResourceNotFoundException;
+import com.chiliclub.chilichat.entity.AdminEntity;
+import com.chiliclub.chilichat.entity.ChatRoomEntity;
+import com.chiliclub.chilichat.entity.UserEntity;
+import com.chiliclub.chilichat.repository.AdminRepository;
+import com.chiliclub.chilichat.repository.ChatRoomRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private AdminRepository adminRepository;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+    @InjectMocks
+    private AdminService adminService;
+
+    private AdminEntity createAdminEntity(UserEntity userEntity, ChatRoomEntity chatRoomEntity, Long adminNo) {
+
+        AdminEntity adminEntity = AdminEntity.builder()
+                .user(userEntity)
+                .chatRoom(chatRoomEntity)
+                .build();
+        ReflectionTestUtils.setField(adminEntity, "no", adminNo);
+
+        return adminEntity;
+    }
+
+    private ChatRoomEntity createChatRoomEntity(Long chatRoomNo) {
+
+        ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
+                .title("test title")
+                .build();
+        ReflectionTestUtils.setField(chatRoomEntity, "no", chatRoomNo);
+
+        return chatRoomEntity;
+    }
+
+    private UserEntity createUserEntity(Long userNo) {
+
+        UserEntity userEntity = UserEntity.builder()
+                .loginId("tester1")
+                .nickname("무키무키")
+                .build();
+        ReflectionTestUtils.setField(userEntity, "no", userNo);
+
+        return userEntity;
+    }
+
+    @Test
+    @DisplayName("유저 ID로 방장 정보를 조회하는 데 성공한다")
+    void testSuccessToFindAdmin() {
+
+        // given
+        Long userNo = 1L;
+        AdminEntity mockAdminEntity = mock(AdminEntity.class);
+
+        given(adminRepository.findByUserNo(userNo))
+                .willReturn(Optional.ofNullable(mockAdminEntity));
+
+        // when
+        AdminEntity foundAdmin = adminService.findAdmin(userNo);
+
+        // then
+        assertThat(foundAdmin).isEqualTo(mockAdminEntity);
+    }
+
+    @Test
+    @DisplayName("유저 ID로 방장 정보를 조회하는 데 실패한다")
+    void testFailToFindAdminIfAdminIsNotExist() {
+
+        // given
+        Long userNo = 1L;
+
+        given(adminRepository.findByUserNo(userNo))
+                .willReturn(Optional.empty());
+
+        // when && then
+        assertThatThrownBy(() -> adminService.findAdmin(userNo))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("유저가 특정 채팅방의 방장이다")
+    void testSuccessToCheckIsAdmin() {
+
+        // given
+        Long userNo = 1L;
+        UserEntity userEntity = createUserEntity(userNo);
+
+        Long chatRoomNo = 2L;
+        ChatRoomEntity chatRoomEntity = createChatRoomEntity(chatRoomNo);
+
+        Long adminNo = 3L;
+        AdminEntity adminEntity = createAdminEntity(userEntity, chatRoomEntity, adminNo);
+
+        given(adminRepository.findByUserNo(userNo))
+                .willReturn(Optional.ofNullable(adminEntity));
+        given(chatRoomRepository.findById(chatRoomNo))
+                .willReturn(Optional.ofNullable(chatRoomEntity));
+
+        // when
+        boolean result = adminService.checkIsAdmin(userNo, chatRoomNo);
+
+        // then
+        assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("유저가 특정 채팅방의 방장이 아니다")
+    void testFailToCheckIsAdmin() {
+
+        // given
+        Long userNo = 1L;
+        UserEntity userEntity = createUserEntity(userNo);
+
+        Long chatRoomNo = 2L;
+        ChatRoomEntity chatRoomEntity = createChatRoomEntity(chatRoomNo);
+
+        Long adminNo = 3L;
+        AdminEntity adminEntity = createAdminEntity(userEntity, chatRoomEntity, adminNo);
+
+        given(adminRepository.findByUserNo(userNo))
+                .willReturn(Optional.ofNullable(adminEntity));
+        given(chatRoomRepository.findById(chatRoomNo))
+                .willReturn(Optional.empty());
+
+        // when && then
+        assertThatThrownBy(() -> adminService.checkIsAdmin(userNo, chatRoomNo))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}


### PR DESCRIPTION
- userService.getCurretUserNo: 현재 세션에 저장된 유저ID 가져올 수 있음
- admin.checkIsAdmin: 해당 유저가 채팅방의 방장인지 체크(예외 던지므로 주의)

Closes #17 