### PR TITLE
[feat] 유저 닉네임 및 프로필 사진 수정 기능 추가

### DIFF
--- a/src/main/java/com/chiliclub/chilichat/controller/UserController.java
+++ b/src/main/java/com/chiliclub/chilichat/controller/UserController.java
@@ -1,9 +1,7 @@
 package com.chiliclub.chilichat.controller;
 
-import com.chiliclub.chilichat.model.user.UserInfoResponse;
-import com.chiliclub.chilichat.model.user.UserSaveRequest;
-import com.chiliclub.chilichat.model.user.UserSignInRequest;
-import com.chiliclub.chilichat.model.user.UserSignInResponse;
+import com.chiliclub.chilichat.component.S3Uploader;
+import com.chiliclub.chilichat.model.user.*;
 import com.chiliclub.chilichat.service.UserService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -11,8 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/user")
@@ -21,6 +21,8 @@ import javax.servlet.http.HttpServletResponse;
 public class UserController {
 
     private final UserService userService;
+
+    private final S3Uploader s3Uploader;
 
     @ApiOperation(value = "회원 등록")
     @PostMapping("/signup")
@@ -50,5 +52,38 @@ public class UserController {
         return ResponseEntity.ok(userService.getUserInfo(
                 userService.getCurrentUserNo()
         ));
+    }
+
+    @ApiOperation(
+            value = "닉네임 수정"
+    )
+    @PatchMapping("/nickname")
+    public ResponseEntity<String> userModifyNickname(
+            @RequestBody UserModifyRequest.Nickname req
+    ) {
+        return ResponseEntity.ok(
+                userService.setUserNickname(
+                        req.getUserNo(),
+                        req.getNickname()
+                )
+        );
+    }
+
+    @ApiOperation(
+            value = "프로필 사진 수정"
+    )
+    @PatchMapping("/picture")
+    public ResponseEntity<String> userModifyPicture(
+            @RequestPart MultipartFile file,
+            @RequestParam Long userNo
+            ) throws IOException {
+
+        String picUrl = s3Uploader.upload(file);
+
+        return ResponseEntity.ok(
+                userService.setUserPicUrl(
+                        userNo,
+                        picUrl)
+        );
     }
 }

--- a/src/main/java/com/chiliclub/chilichat/entity/UserEntity.java
+++ b/src/main/java/com/chiliclub/chilichat/entity/UserEntity.java
@@ -50,6 +50,10 @@ public class UserEntity extends BaseEntity {
         this.picUrl = picUrl;
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     public static UserEntity create(
             UserSaveRequest req,
             PasswordEncoder passwordEncoder,

--- a/src/main/java/com/chiliclub/chilichat/model/user/UserModifyRequest.java
+++ b/src/main/java/com/chiliclub/chilichat/model/user/UserModifyRequest.java
@@ -1,0 +1,20 @@
+package com.chiliclub.chilichat.model.user;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserModifyRequest {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel
+    public static class Nickname {
+        private Long userNo;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/chiliclub/chilichat/service/UserService.java
+++ b/src/main/java/com/chiliclub/chilichat/service/UserService.java
@@ -1,6 +1,7 @@
 package com.chiliclub.chilichat.service;
 
 import com.chiliclub.chilichat.common.exception.InvalidReqParamException;
+import com.chiliclub.chilichat.common.exception.RequestForbiddenException;
 import com.chiliclub.chilichat.common.exception.ResourceNotFoundException;
 import com.chiliclub.chilichat.common.exception.UserNotAuthorizedException;
 import com.chiliclub.chilichat.component.S3Uploader;
@@ -20,6 +21,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -94,5 +96,37 @@ public class UserService {
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 유저입니다."));
 
         return UserInfoResponse.from(userEntity);
+    }
+
+    private void checkUserAuth(Long userNo) {
+        if (userNo.compareTo(getCurrentUserNo()) != 0) {
+            throw new RequestForbiddenException();
+        }
+    }
+
+    @Transactional
+    public String setUserNickname(Long userNo, String nickname) {
+
+        checkUserAuth(userNo);
+
+        UserEntity userEntity = userRepository.findById(userNo)
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 유저입니다."));
+
+        userEntity.updateNickname(nickname);
+
+        return nickname;
+    }
+
+    @Transactional
+    public String setUserPicUrl(Long userNo, String picUrl) {
+
+        checkUserAuth(userNo);
+
+        UserEntity userEntity = userRepository.findById(userNo)
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 유저입니다."));
+
+        userEntity.updatePicUrl(picUrl);
+
+        return picUrl;
     }
 }

--- a/src/test/java/com/chiliclub/chilichat/service/UserServiceTest.java
+++ b/src/test/java/com/chiliclub/chilichat/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.chiliclub.chilichat.service;
 
 import com.chiliclub.chilichat.common.exception.InvalidReqParamException;
+import com.chiliclub.chilichat.common.exception.RequestForbiddenException;
 import com.chiliclub.chilichat.common.exception.ResourceNotFoundException;
 import com.chiliclub.chilichat.component.S3Uploader;
 import com.chiliclub.chilichat.entity.UserEntity;
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +36,7 @@ class UserServiceTest {
     private PasswordEncoder passwordEncoder;
     @Mock
     private S3Uploader s3Uploader;
+    @Spy
     @InjectMocks
     private UserService userService;
 
@@ -48,7 +50,7 @@ class UserServiceTest {
 
     private UserEntity createUserEntity(
             UserSaveRequest req,
-            Long userEntityNo,
+            Long userNo,
             String defaultPicUrl
     ) {
 
@@ -57,7 +59,7 @@ class UserServiceTest {
                 passwordEncoder,
                 defaultPicUrl);
 
-        ReflectionTestUtils.setField(userEntity, "no", userEntityNo);
+        ReflectionTestUtils.setField(userEntity, "no", userNo);
 
         return userEntity;
     }
@@ -69,12 +71,12 @@ class UserServiceTest {
 
         // given
         UserSaveRequest req = createAddUserRequest();
-        Long userEntityNo = 1L;
+        Long userNo = 1L;
         String defaultPicUrl = "https://test/img.png";
 
         UserEntity userEntity = createUserEntity(
                 req,
-                userEntityNo,
+                userNo,
                 defaultPicUrl);
 
         given(userRepository.findByLoginId(any(String.class)))
@@ -99,12 +101,12 @@ class UserServiceTest {
 
         // given
         UserSaveRequest req = createAddUserRequest();
-        Long userEntityNo = 1L;
+        Long userNo = 1L;
         String defaultPicUrl = "https://test/img.png";
 
         UserEntity userEntity = createUserEntity(
                 req,
-                userEntityNo,
+                userNo,
                 defaultPicUrl);
 
         given(userRepository.findByLoginId(any(String.class)))
@@ -122,12 +124,12 @@ class UserServiceTest {
 
         // given
         UserSaveRequest req = createAddUserRequest();
-        Long userEntityNo = 1L;
+        Long userNo = 1L;
         String defaultPicUrl = "https://test/img.png";
 
         UserEntity userEntity = createUserEntity(
                 req,
-                userEntityNo,
+                userNo,
                 defaultPicUrl);
 
         given(userRepository.findByLoginId(any(String.class)))
@@ -178,8 +180,8 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("유저 프로필을 가져오는 데 실패한다")
-    void testFailToGetUserInfo() {
+    @DisplayName("유저가 존재하지 않을 경우 유저 프로필을 가져오는 데 실패한다")
+    void testFailToGetUserInfoIfUserIsNotExist() {
 
         // given
         Long userNo = 1L;
@@ -189,6 +191,128 @@ class UserServiceTest {
 
         // when && then
         assertThatThrownBy(() -> userService.getUserInfo(userNo))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("존재하지 않는 유저입니다.");
+    }
+
+    @Test
+    @DisplayName("유저의 닉네임을 수정하는 데 성공한다")
+    void testSuccessToSetUserNickname() {
+
+        // given
+        UserSaveRequest req = createAddUserRequest();
+        Long userNo = 1L;
+        String defaultPicUrl = "https://test/img.png";
+
+        UserEntity userEntity = createUserEntity(
+                req,
+                userNo,
+                defaultPicUrl);
+
+        String newNickname = "루드 굴리트";
+
+        doReturn(userNo).when(userService).getCurrentUserNo();
+        given(userRepository.findById(userNo)).willReturn(Optional.ofNullable(userEntity));
+
+        // when
+        String result = userService.setUserNickname(userNo, newNickname);
+
+        // then
+        assert userEntity != null;
+        assertThat(userEntity.getNickname()).isEqualTo(newNickname);
+        assertThat(newNickname).isEqualTo(result);
+    }
+
+    @Test
+    @DisplayName("인증되지 않을 경우 유저의 닉네임을 수정하는 데 실패한다")
+    void testFailToSetUserNicknameIfUserIsNotAuthorized() {
+
+        // given
+        Long userNo = 1L;
+        String newNickname = "루드 굴리트";
+
+        doReturn(2L).when(userService).getCurrentUserNo();
+
+        // when && then
+        assertThatThrownBy(() -> userService.setUserNickname(userNo, newNickname))
+                .isInstanceOf(RequestForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않을 경우 유저의 닉네임을 수정하는 데 실패한다")
+    void testFailToSetUserNicknameIfUserIsNotExist() {
+
+        // given
+        Long userNo = 1L;
+        String newNickname = "루드 굴리트";
+
+        doReturn(userNo).when(userService).getCurrentUserNo();
+        given(userRepository.findById(userNo))
+                .willReturn(Optional.empty());
+
+        // when && then
+        assertThatThrownBy(() -> userService.setUserNickname(userNo, newNickname))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("존재하지 않는 유저입니다.");
+    }
+
+    @Test
+    @DisplayName("유저의 프로필 사진을 수정하는 데 성공한다")
+    void testSuccessToSetUserPicUrl() {
+
+        // given
+        UserSaveRequest req = createAddUserRequest();
+        Long userNo = 1L;
+        String defaultPicUrl = "https://test/img.png";
+
+        UserEntity userEntity = createUserEntity(
+                req,
+                userNo,
+                defaultPicUrl);
+
+        String newPicUrl = "https://test/new-img.png";
+
+        doReturn(userNo).when(userService).getCurrentUserNo();
+        given(userRepository.findById(userNo)).willReturn(Optional.ofNullable(userEntity));
+
+        // when
+        String result = userService.setUserPicUrl(userNo, newPicUrl);
+
+        // then
+        assert userEntity != null;
+        assertThat(userEntity.getPicUrl()).isEqualTo(newPicUrl);
+        assertThat(newPicUrl).isEqualTo(result);
+    }
+
+    @Test
+    @DisplayName("인증되지 않을 경우 유저의 프로필 사진을 수정하는 데 실패한다")
+    void testFailToSetUserPicUrlIfUserIsNotAuthorized() {
+
+        // given
+        Long userNo = 1L;
+        String newPicUrl = "https://test/new-img.png";
+
+        doReturn(2L).when(userService).getCurrentUserNo();
+
+        // when && then
+        assertThatThrownBy(() -> userService.setUserPicUrl(userNo, newPicUrl))
+                .isInstanceOf(RequestForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않을 경우 유저의 프로필 사진을 수정하는 데 실패한다")
+    void testFailToSetUserPicUrlIfUserIsNotExist() {
+
+        // given
+        Long userNo = 1L;
+        String newPicUrl = "https://test/new-img.png";
+
+        doReturn(userNo).when(userService).getCurrentUserNo();
+        given(userRepository.findById(userNo))
+                .willReturn(Optional.empty());
+
+        // when && then
+        assertThatThrownBy(() -> userService.setUserPicUrl(userNo, newPicUrl))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("존재하지 않는 유저입니다.");
     }


### PR DESCRIPTION
- 유저 닉네임 및 프로필 사진 수정 API 추가
- 프로필 사진 변경 시 parameter에 userNo, form data로 실제 파일 보내줘야 함(patch)
- 현재 DB에 full url이 다 저장되는 형태인데 path만 저장되도록 수정할 예정

Closes #23 