### PR TITLE
[feat] 채팅방 생성 시 admin, user_chatroom 엔티티 저장 로직 수정

### DIFF
--- a/src/main/java/com/chiliclub/chilichat/entity/ChatRoomEntity.java
+++ b/src/main/java/com/chiliclub/chilichat/entity/ChatRoomEntity.java
@@ -48,6 +48,11 @@ public class ChatRoomEntity extends BaseEntity {
         return chatRoomEntity;
     }
 
+    public void setAdmin(AdminEntity admin) {
+        this.admin = admin;
+        admin.setChatRoom(this);
+    }
+
     public void update(ChatRoomUpdateRequest req) {
         this.title = req.getTitle();
     }

--- a/src/main/java/com/chiliclub/chilichat/entity/UserChatRoomEntity.java
+++ b/src/main/java/com/chiliclub/chilichat/entity/UserChatRoomEntity.java
@@ -28,8 +28,14 @@ public class UserChatRoomEntity extends BaseEntity {
 
     @Builder
     public UserChatRoomEntity(Long no, UserEntity user, ChatRoomEntity chatRoom) {
-        this.no = no;
         this.user = user;
         this.chatRoom = chatRoom;
+    }
+
+    public static UserChatRoomEntity create(UserEntity user, ChatRoomEntity chatRoom) {
+        return UserChatRoomEntity.builder()
+                .user(user)
+                .chatRoom(chatRoom)
+                .build();
     }
 }

--- a/src/main/java/com/chiliclub/chilichat/service/ChatRoomService.java
+++ b/src/main/java/com/chiliclub/chilichat/service/ChatRoomService.java
@@ -40,12 +40,18 @@ public class ChatRoomService {
     public Long addChatRoom(ChatRoomCreateRequest chatRoomCreateRequest) {
 
         ChatRoomEntity chatRoom = ChatRoomEntity.create(chatRoomCreateRequest);
-        UserEntity currentUser = userRepository.findByNo(userService.getCurrentUserNo());
 
         // 현재 사용자를 Admin으로 생성
-        adminRepository.save(AdminEntity.create(currentUser, chatRoom));
+        UserEntity currentUser = userRepository.findByNo(userService.getCurrentUserNo());
+        AdminEntity admin = AdminEntity.create(currentUser, chatRoom);
 
-        return chatRoomRepository.save(ChatRoomEntity.create(chatRoomCreateRequest)).getNo();
+        chatRoom.setAdmin(admin);
+        Long addedChatRoomNo = chatRoomRepository.save(chatRoom).getNo();
+        adminRepository.save(admin);
+
+        userChatRoomRepository.save(UserChatRoomEntity.create(currentUser, chatRoom));
+
+        return addedChatRoomNo;
     }
 
     public List<ChatRoomFindResponse> findChatRoomList() {


### PR DESCRIPTION
오류 발생 원인
- ChatRoomEntity에 admin 필드 추가된 부분이 채팅방 생성 로직에 영향

수정사항
- ChatRoomEntity에 admin setter 생성하여 저장하도록 수정
- 어드민 또한 채팅방 참여자이므로 UserChatRoomEntity 객체 생성되도록 수정